### PR TITLE
fix tests

### DIFF
--- a/src/PowerSystemsInvestmentsPortfolios.jl
+++ b/src/PowerSystemsInvestmentsPortfolios.jl
@@ -11,6 +11,7 @@ import InfrastructureSystems:
     get_time_series_timestamps,
     get_time_series_values,
     supports_time_series,
+    get_available,
     InfrastructureSystemsInternal,
     CompressionSettings,
     CompressionTypes,

--- a/src/investment_schedule.jl
+++ b/src/investment_schedule.jl
@@ -21,5 +21,5 @@ mutable struct InvestmentScheduleResults <: IS.InfrastructureSystemsType
     # InvestmentPeriod => (TypeTechnology, "name") => BuildCapacity
     # InvestmentPeriod is a (start_date, end_date) tuple and BuildCapacity is either a
     # scalar (Float64) or a NamedTuple of named build quantities, so this stays untyped.
-    results::Dict
+    results::Dict{Any, Any}
 end

--- a/src/investment_schedule.jl
+++ b/src/investment_schedule.jl
@@ -18,5 +18,8 @@ A mutable struct that stores the results of investment decisions over multiple i
       + BuildCapacity: The capacity to be built for that technology in that period
 """
 mutable struct InvestmentScheduleResults <: IS.InfrastructureSystemsType
-    results::Dict{Int, Dict{Tuple{Type{<:Technology}, String}, Float64}} # InvestmentPeriod => (TypeTechnology, "name") => BuildCapacity
+    # InvestmentPeriod => (TypeTechnology, "name") => BuildCapacity
+    # InvestmentPeriod is a (start_date, end_date) tuple and BuildCapacity is either a
+    # scalar (Float64) or a NamedTuple of named build quantities, so this stays untyped.
+    results::Dict
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -11,6 +11,8 @@ const _CONTAINS_SHOULD_ENCODE = Union{
     TransmissionTechnology,
     Requirement,
     ExistingCapacity,
+    RetrofitPotential,
+    TopologyMapping,
     RegionTopology,
 }
 const SYSTEM_KWARGS = Set((


### PR DESCRIPTION
Misc test fixes. Summary per Claude:

>   1. `get_available` not implemented (src/PowerSystemsInvestmentsPortfolios.jl) — `get_available` wasn't imported from InfrastructureSystems, so `get_available` methods extended a local function instead of `IS.get_available`.
>   2. `Base.UUID(nothing)` crash on deserialize (src/serialization.jl) — `RetrofitPotential` and `TopologyMapping` carry a flat uuid field in their OpenAPI models but were missing from `_CONTAINS_SHOULD_ENCODE`, so they serialized via IS's default path (uuid nested in internal) while the deserializer expected a flat uuid string.
>   3. Stale results field type (src/investment_schedule.jl) — the field was declared `Dict{Int, Dict{Tuple{Type{<:Technology}, String}, Float64}}`, but the actual data is `Tuple{Date,Date} → (TechType, name) → Float64 | NamedTuple` (a leftover from release-prep commit 3a1c03e). Fix: relaxed it to a plain Dict.