### PR TITLE
Portfolio input validation for investment technologies

### DIFF
--- a/src/PowerSystemsInvestmentsPortfolios.jl
+++ b/src/PowerSystemsInvestmentsPortfolios.jl
@@ -110,6 +110,9 @@ export set_investment_schedule!
 export set_base_system!
 export add_technology!
 export add_technologies!
+export validate_technology
+export check_technology
+export check_technologies
 export remove_technology!
 export add_region!
 export add_requirement!
@@ -176,6 +179,7 @@ include("models/generated/includes.jl")
 include("investment_schedule.jl")
 
 include("portfolio.jl")
+include("validation.jl")
 include("time_mapping.jl")
 include("serialization.jl")
 include("generate_structs.jl")

--- a/src/portfolio.jl
+++ b/src/portfolio.jl
@@ -318,14 +318,6 @@ Set the base system of the portfolio.
 set_base_system!(val::Portfolio, system::PSY.System) = val.base_system = system
 
 """
-Validate a component against System data. Return true if the instance is valid.
-
-Refer to [`validate_technology`](@ref) if the validation logic only requires data contained
-within the instance.
-"""
-validate_component_with_system(technology::Technology, port::Portfolio) = true
-
-"""
 Add a technology to the portfolio.
 
 Throws ArgumentError if the technology's name is already stored for its concrete type.

--- a/src/portfolio.jl
+++ b/src/portfolio.jl
@@ -811,6 +811,7 @@ function add_region!(
     kwargs...,
 ) where {T <: RegionTopology}
     deserialization_in_progress = _is_deserialization_in_progress(portfolio)
+    skip_validation = _validate_or_skip!(portfolio, zone, skip_validation)
     IS.add_component!(
         portfolio.data,
         zone;

--- a/src/portfolio.jl
+++ b/src/portfolio.jl
@@ -354,7 +354,7 @@ function add_technology!(
     #    check_for_services_on_addition(portfolio, technology)
     #end
 
-    skip_validation = true #_validate_or_skip!(portfolio, technology, skip_validation)
+    skip_validation = _validate_or_skip!(portfolio, technology, skip_validation)
     _kwargs = Dict(k => v for (k, v) in kwargs if k !== :static_injector)
 
     IS.add_component!(

--- a/src/portfolio.jl
+++ b/src/portfolio.jl
@@ -320,7 +320,7 @@ set_base_system!(val::Portfolio, system::PSY.System) = val.base_system = system
 """
 Validate a component against System data. Return true if the instance is valid.
 
-Refer to [`validate_component`](@ref) if the validation logic only requires data contained
+Refer to [`validate_technology`](@ref) if the validation logic only requires data contained
 within the instance.
 """
 validate_component_with_system(technology::Technology, port::Portfolio) = true

--- a/src/utils/print_pt_v3.jl
+++ b/src/utils/print_pt_v3.jl
@@ -127,21 +127,21 @@ function Base.show(io::IO, ::MIME"text/plain", p::Portfolio)
 end
 
 function Base.show(io::IO, ::MIME"text/html", p::Portfolio)
-    show_portfolio_table(io, p; backend=:html, standalone=false)
+    show_portfolio_table(io, p; backend=:html, stand_alone=false)
     println(io)
     show_region_topology_table(
         io,
         p;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     show_technologies_table(
         io,
         p;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     println(io)
     println(io, "Time Series")
@@ -150,7 +150,7 @@ function Base.show(io::IO, ::MIME"text/html", p::Portfolio)
         p.data;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     return
 end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -147,8 +147,29 @@ function _validate_storage_fields(technology::StorageTechnology)
     return is_valid
 end
 
-validate_technology(technology::SupplyTechnology) =
-    _validate_positive_value(technology, get_lifetime(technology), "Technology lifetime")
+function validate_technology(technology::SupplyTechnology)
+    is_valid = _validate_positive_value(
+        technology,
+        get_lifetime(technology),
+        "Technology lifetime",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits(technology),
+        "Supply capacity limits",
+    )
+    is_valid &= _validate_nonnegative_value(
+        technology,
+        get_unit_size(technology),
+        "Supply unit size",
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        get_min_generation_fraction(technology),
+        "Supply minimum generation fraction",
+    )
+    return is_valid
+end
 
 function validate_technology(technology::StorageTechnology)
     is_valid = _validate_positive_value(
@@ -157,6 +178,90 @@ function validate_technology(technology::StorageTechnology)
         "Technology lifetime",
     )
     is_valid &= _validate_storage_fields(technology)
+    return is_valid
+end
+
+function _validate_colocated_supply_storage_fields(
+    technology::ColocatedSupplyStorageTechnology,
+)
+    is_valid = _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits_wind(technology),
+        "Colocated wind capacity limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits_solar(technology),
+        "Colocated solar capacity limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_power_limits(technology),
+        "Colocated storage power capacity limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_energy_limits(technology),
+        "Colocated storage energy capacity limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_duration_limits(technology),
+        "Colocated storage duration limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        (
+            min=get_min_inverter_capacity(technology),
+            max=get_max_inverter_capacity(technology),
+        ),
+        "Colocated inverter capacity limits",
+    )
+
+    efficiency = get_efficiency_storage(technology)
+    is_valid &= _validate_fraction(
+        technology,
+        efficiency.in,
+        "Colocated storage charging efficiency";
+        strictly_positive=true,
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        efficiency.out,
+        "Colocated storage discharging efficiency";
+        strictly_positive=true,
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        get_inverter_efficiency(technology),
+        "Colocated inverter efficiency";
+        strictly_positive=true,
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        get_losses_storage(technology),
+        "Colocated storage losses",
+    )
+    return is_valid
+end
+
+function validate_technology(technology::ColocatedSupplyStorageTechnology)
+    is_valid = _validate_positive_value(
+        technology,
+        get_lifetime_storage(technology),
+        "Colocated storage lifetime",
+    )
+    is_valid &= _validate_positive_value(
+        technology,
+        get_lifetime_wind(technology),
+        "Colocated wind lifetime",
+    )
+    is_valid &= _validate_positive_value(
+        technology,
+        get_lifetime_solar(technology),
+        "Colocated solar lifetime",
+    )
+    is_valid &= _validate_colocated_supply_storage_fields(technology)
     return is_valid
 end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -75,18 +75,6 @@ function _validate_fraction(technology, value, field_name; strictly_positive=fal
     return true
 end
 
-function _validate_lifetime(technology::Union{SupplyTechnology, StorageTechnology})
-    if get_lifetime(technology) <= 0
-        @error(
-            "Technology lifetime must be positive",
-            technology = get_name(technology),
-            lifetime = get_lifetime(technology),
-        )
-        return false
-    end
-    return true
-end
-
 function _validate_storage_fields(technology::StorageTechnology)
     is_valid = true
 
@@ -159,10 +147,15 @@ function _validate_storage_fields(technology::StorageTechnology)
     return is_valid
 end
 
-validate_technology(technology::SupplyTechnology) = _validate_lifetime(technology)
+validate_technology(technology::SupplyTechnology) =
+    _validate_positive_value(technology, get_lifetime(technology), "Technology lifetime")
 
 function validate_technology(technology::StorageTechnology)
-    is_valid = _validate_lifetime(technology)
+    is_valid = _validate_positive_value(
+        technology,
+        get_lifetime(technology),
+        "Technology lifetime",
+    )
     is_valid &= _validate_storage_fields(technology)
     return is_valid
 end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -5,21 +5,222 @@ Return `true` if the technology is valid.
 """
 validate_technology(::Technology) = true
 
-function validate_technology(technology::StorageTechnology)
-    duration_limits = get_duration_limits(technology)
-    if !(duration_limits.min <= duration_limits.max)
+function _validate_nonnegative_limits(technology, limits, field_name)
+    is_valid = true
+    if !isfinite(limits.min) || !isfinite(limits.max)
         @error(
-            "Storage duration limits must be in ascending order",
+            "$field_name must be finite",
             technology=get_name(technology),
-            minimum=duration_limits.min,
-            maximum=duration_limits.max,
+            minimum=limits.min,
+            maximum=limits.max,
+        )
+        is_valid = false
+    end
+    if limits.min < 0.0 || limits.max < 0.0
+        @error(
+            "$field_name must be nonnegative",
+            technology=get_name(technology),
+            minimum=limits.min,
+            maximum=limits.max,
+        )
+        is_valid = false
+    end
+    if limits.min > limits.max
+        @error(
+            "$field_name must be in ascending order",
+            technology=get_name(technology),
+            minimum=limits.min,
+            maximum=limits.max,
+        )
+        is_valid = false
+    end
+    return is_valid
+end
+
+function _validate_nonnegative_value(technology, value, field_name)
+    if !isfinite(value) || value < 0.0
+        @error(
+            "$field_name must be finite and nonnegative",
+            technology=get_name(technology),
+            value,
         )
         return false
     end
     return true
 end
 
+function _validate_fraction(technology, value, field_name; strictly_positive=false)
+    lower_bound_is_valid = strictly_positive ? value > 0.0 : value >= 0.0
+    if !isfinite(value) || !lower_bound_is_valid || value > 1.0
+        interval = strictly_positive ? "(0, 1]" : "[0, 1]"
+        @error(
+            "$field_name must be in $interval",
+            technology=get_name(technology),
+            value,
+        )
+        return false
+    end
+    return true
+end
+
+function validate_technology(technology::StorageTechnology)
+    is_valid = true
+
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_duration_limits(technology),
+        "Storage duration limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits_energy(technology),
+        "Storage energy capacity limits",
+    )
+    is_valid &= _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits_discharge(technology),
+        "Storage discharge capacity limits",
+    )
+
+    charge_capacity_limits = get_capacity_limits_charge(technology)
+    if !isnothing(charge_capacity_limits)
+        is_valid &= _validate_nonnegative_limits(
+            technology,
+            charge_capacity_limits,
+            "Storage charge capacity limits",
+        )
+    end
+
+    is_valid &= _validate_nonnegative_value(
+        technology,
+        get_unit_size_energy(technology),
+        "Storage energy unit size",
+    )
+    is_valid &= _validate_nonnegative_value(
+        technology,
+        get_unit_size_discharge(technology),
+        "Storage discharge unit size",
+    )
+
+    charge_unit_size = get_unit_size_charge(technology)
+    if !isnothing(charge_unit_size)
+        is_valid &= _validate_nonnegative_value(
+            technology,
+            charge_unit_size,
+            "Storage charge unit size",
+        )
+    end
+
+    is_valid &= _validate_fraction(
+        technology,
+        get_min_discharge_fraction(technology),
+        "Storage minimum discharge fraction",
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        get_losses(technology),
+        "Storage losses",
+    )
+
+    efficiency = get_efficiency(technology)
+    is_valid &= _validate_fraction(
+        technology,
+        efficiency.in,
+        "Storage charging efficiency";
+        strictly_positive=true,
+    )
+    is_valid &= _validate_fraction(
+        technology,
+        efficiency.out,
+        "Storage discharging efficiency";
+        strictly_positive=true,
+    )
+
+    if get_lifetime(technology) <= 0
+        @error(
+            "Storage lifetime must be positive",
+            technology=get_name(technology),
+            lifetime=get_lifetime(technology),
+        )
+        is_valid = false
+    end
+
+    return is_valid
+end
+
 IS.validate_struct(technology::Technology) = validate_technology(technology)
+
+"""
+Validate a technology using data from the portfolio.
+
+Use [`validate_technology`](@ref) when validation only requires data contained within the
+technology itself.
+
+Return `true` if the technology is valid.
+"""
+validate_technology_with_portfolio(::Technology, ::Portfolio) = true
+
+function _validate_unique_references(technology, references, reference_type)
+    uuids = IS.get_uuid.(references)
+    if !allunique(uuids)
+        @error(
+            "Storage technology contains duplicate $reference_type references",
+            technology=get_name(technology),
+        )
+        return false
+    end
+    return true
+end
+
+function _validate_attached_references(
+    technology,
+    references,
+    portfolio,
+    reference_type,
+)
+    is_valid = true
+    for reference in references
+        if !IS.has_component(portfolio.data, reference)
+            @error(
+                "Storage technology references a $reference_type that is not attached to the portfolio",
+                technology=get_name(technology),
+                reference=summary(reference),
+            )
+            is_valid = false
+        end
+    end
+    return is_valid
+end
+
+function validate_technology_with_portfolio(
+    technology::StorageTechnology,
+    portfolio::Portfolio,
+)
+    is_valid = true
+    regions = get_region(technology)
+    if isempty(regions)
+        @error(
+            "Storage technology must reference at least one region",
+            technology=get_name(technology),
+        )
+        is_valid = false
+    else
+        is_valid &= _validate_unique_references(technology, regions, "region")
+        is_valid &=
+            _validate_attached_references(technology, regions, portfolio, "region")
+    end
+
+    requirements = get_requirements(technology)
+    is_valid &= _validate_unique_references(technology, requirements, "requirement")
+    is_valid &= _validate_attached_references(
+        technology,
+        requirements,
+        portfolio,
+        "requirement",
+    )
+
+    return is_valid
+end
 
 """
 Check one technology using technology-only and portfolio-aware validation.
@@ -28,7 +229,7 @@ Throw [`IS.InvalidValue`](@ref) if the technology is invalid.
 """
 function check_technology(portfolio::Portfolio, technology::Technology)
     if !validate_technology(technology) ||
-       !validate_component_with_system(technology, portfolio)
+       !validate_technology_with_portfolio(technology, portfolio)
         throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
     end
     return

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -1,0 +1,47 @@
+"""
+Validate a technology using only information contained within the technology.
+
+Return `true` if the technology is valid.
+"""
+validate_technology(::Technology) = true
+
+function validate_technology(technology::StorageTechnology)
+    duration_limits = get_duration_limits(technology)
+    if !(duration_limits.min <= duration_limits.max)
+        @error(
+            "Storage duration limits must be in ascending order",
+            technology=get_name(technology),
+            minimum=duration_limits.min,
+            maximum=duration_limits.max,
+        )
+        return false
+    end
+    return true
+end
+
+IS.validate_struct(technology::Technology) = validate_technology(technology)
+
+"""
+Check one technology using technology-only and portfolio-aware validation.
+
+Throw [`IS.InvalidValue`](@ref) if the technology is invalid.
+"""
+function check_technology(portfolio::Portfolio, technology::Technology)
+    if !validate_technology(technology) ||
+       !validate_component_with_system(technology, portfolio)
+        throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
+    end
+    return
+end
+
+"""
+Check every technology in an iterable.
+
+Throw [`IS.InvalidValue`](@ref) when a technology is invalid.
+"""
+function check_technologies(portfolio::Portfolio, technologies)
+    for technology in technologies
+        check_technology(portfolio, technology)
+    end
+    return
+end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -222,16 +222,28 @@ function validate_technology_with_portfolio(
     return is_valid
 end
 
+function _validate_or_skip!(
+    portfolio::Portfolio,
+    technology::Technology,
+    skip_validation::Bool,
+)
+    if !skip_validation &&
+       !validate_technology_with_portfolio(technology, portfolio)
+        throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
+    end
+    return skip_validation
+end
+
 """
 Check one technology using technology-only and portfolio-aware validation.
 
 Throw [`IS.InvalidValue`](@ref) if the technology is invalid.
 """
 function check_technology(portfolio::Portfolio, technology::Technology)
-    if !validate_technology(technology) ||
-       !validate_technology_with_portfolio(technology, portfolio)
+    if !validate_technology_with_portfolio(technology, portfolio)
         throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
     end
+    IS.check_component(portfolio.data, technology)
     return
 end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -10,27 +10,27 @@ function _validate_nonnegative_limits(technology, limits, field_name)
     if !isfinite(limits.min) || !isfinite(limits.max)
         @error(
             "$field_name must be finite",
-            technology=get_name(technology),
-            minimum=limits.min,
-            maximum=limits.max,
+            technology = get_name(technology),
+            minimum = limits.min,
+            maximum = limits.max,
         )
         is_valid = false
     end
     if limits.min < 0.0 || limits.max < 0.0
         @error(
             "$field_name must be nonnegative",
-            technology=get_name(technology),
-            minimum=limits.min,
-            maximum=limits.max,
+            technology = get_name(technology),
+            minimum = limits.min,
+            maximum = limits.max,
         )
         is_valid = false
     end
     if limits.min > limits.max
         @error(
             "$field_name must be in ascending order",
-            technology=get_name(technology),
-            minimum=limits.min,
-            maximum=limits.max,
+            technology = get_name(technology),
+            minimum = limits.min,
+            maximum = limits.max,
         )
         is_valid = false
     end
@@ -41,7 +41,7 @@ function _validate_nonnegative_value(technology, value, field_name)
     if !isfinite(value) || value < 0.0
         @error(
             "$field_name must be finite and nonnegative",
-            technology=get_name(technology),
+            technology = get_name(technology),
             value,
         )
         return false
@@ -53,7 +53,7 @@ function _validate_positive_value(technology, value, field_name)
     if !isfinite(value) || value <= 0.0
         @error(
             "$field_name must be finite and positive",
-            technology=get_name(technology),
+            technology = get_name(technology),
             value,
         )
         return false
@@ -67,7 +67,7 @@ function _validate_fraction(technology, value, field_name; strictly_positive=fal
         interval = strictly_positive ? "(0, 1]" : "[0, 1]"
         @error(
             "$field_name must be in $interval",
-            technology=get_name(technology),
+            technology = get_name(technology),
             value,
         )
         return false
@@ -75,14 +75,12 @@ function _validate_fraction(technology, value, field_name; strictly_positive=fal
     return true
 end
 
-function _validate_lifetime(
-    technology::Union{SupplyTechnology, StorageTechnology},
-)
+function _validate_lifetime(technology::Union{SupplyTechnology, StorageTechnology})
     if get_lifetime(technology) <= 0
         @error(
             "Technology lifetime must be positive",
-            technology=get_name(technology),
-            lifetime=get_lifetime(technology),
+            technology = get_name(technology),
+            lifetime = get_lifetime(technology),
         )
         return false
     end
@@ -142,11 +140,7 @@ function _validate_storage_fields(technology::StorageTechnology)
         get_min_discharge_fraction(technology),
         "Storage minimum discharge fraction",
     )
-    is_valid &= _validate_fraction(
-        technology,
-        get_losses(technology),
-        "Storage losses",
-    )
+    is_valid &= _validate_fraction(technology, get_losses(technology), "Storage losses")
 
     efficiency = get_efficiency(technology)
     is_valid &= _validate_fraction(
@@ -165,8 +159,7 @@ function _validate_storage_fields(technology::StorageTechnology)
     return is_valid
 end
 
-validate_technology(technology::SupplyTechnology) =
-    _validate_lifetime(technology)
+validate_technology(technology::SupplyTechnology) = _validate_lifetime(technology)
 
 function validate_technology(technology::StorageTechnology)
     is_valid = _validate_lifetime(technology)
@@ -213,18 +206,15 @@ Return `true` if the technology is valid.
 """
 validate_technology_with_portfolio(::Technology, ::Portfolio) = true
 
-function _validate_unique_region_id(
-    region::RegionTopology,
-    portfolio::Portfolio,
-)
+function _validate_unique_region_id(region::RegionTopology, portfolio::Portfolio)
     region_id = get_id(region)
     for stored_region in get_regions(RegionTopology, portfolio)
         if get_id(stored_region) == region_id
             @error(
                 "Region ID is already attached to the portfolio",
-                region=summary(region),
-                id=region_id,
-                stored_region=summary(stored_region),
+                region = summary(region),
+                id = region_id,
+                stored_region = summary(stored_region),
             )
             return false
         end
@@ -241,7 +231,7 @@ function _validate_unique_references(
     if !allunique(uuids)
         @error(
             "Technology contains duplicate $reference_type references",
-            technology=get_name(technology),
+            technology = get_name(technology),
         )
         return false
     end
@@ -259,8 +249,8 @@ function _validate_attached_references(
         if !IS.has_component(portfolio.data, reference)
             @error(
                 "Technology references a $reference_type that is not attached to the portfolio",
-                technology=get_name(technology),
-                reference=summary(reference),
+                technology = get_name(technology),
+                reference = summary(reference),
             )
             is_valid = false
         end
@@ -276,31 +266,24 @@ function _validate_region_references(
     if isempty(regions)
         @error(
             "Technology must reference at least one region",
-            technology=get_name(technology),
+            technology = get_name(technology),
         )
         return false
     end
 
     is_valid = _validate_unique_references(technology, regions, "region")
-    is_valid &=
-        _validate_attached_references(technology, regions, portfolio, "region")
+    is_valid &= _validate_attached_references(technology, regions, portfolio, "region")
     return is_valid
 end
 
-_get_transport_endpoints(technology::AggregateTransportTechnology) = (
-    get_start_region(technology),
-    get_end_region(technology),
-)
+_get_transport_endpoints(technology::AggregateTransportTechnology) =
+    (get_start_region(technology), get_end_region(technology))
 
-_get_transport_endpoints(technology::NodalACTransportTechnology) = (
-    get_start_node(technology),
-    get_end_node(technology),
-)
+_get_transport_endpoints(technology::NodalACTransportTechnology) =
+    (get_start_node(technology), get_end_node(technology))
 
-_get_transport_endpoints(technology::NodalHVDCTransportTechnology) = (
-    get_start_node(technology),
-    get_end_node(technology),
-)
+_get_transport_endpoints(technology::NodalHVDCTransportTechnology) =
+    (get_start_node(technology), get_end_node(technology))
 
 function _validate_transport_endpoints(
     technology::TransmissionTechnology,
@@ -308,14 +291,13 @@ function _validate_transport_endpoints(
 )
     start_endpoint, end_endpoint = _get_transport_endpoints(technology)
     is_valid = true
-    for (endpoint_name, endpoint) in
-        (("start", start_endpoint), ("end", end_endpoint))
+    for (endpoint_name, endpoint) in (("start", start_endpoint), ("end", end_endpoint))
         if !IS.has_component(portfolio.data, endpoint)
             @error(
                 "Transport endpoint is not attached to the portfolio",
-                technology=get_name(technology),
-                endpoint=endpoint_name,
-                reference=summary(endpoint),
+                technology = get_name(technology),
+                endpoint = endpoint_name,
+                reference = summary(endpoint),
             )
             is_valid = false
         end
@@ -340,8 +322,7 @@ function _validate_or_skip!(
     technology::Technology,
     skip_validation::Bool,
 )
-    if !skip_validation &&
-       !validate_technology_with_portfolio(technology, portfolio)
+    if !skip_validation && !validate_technology_with_portfolio(technology, portfolio)
         throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
     end
     return skip_validation

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -49,6 +49,18 @@ function _validate_nonnegative_value(technology, value, field_name)
     return true
 end
 
+function _validate_positive_value(technology, value, field_name)
+    if !isfinite(value) || value <= 0.0
+        @error(
+            "$field_name must be finite and positive",
+            technology=get_name(technology),
+            value,
+        )
+        return false
+    end
+    return true
+end
+
 function _validate_fraction(technology, value, field_name; strictly_positive=false)
     lower_bound_is_valid = strictly_positive ? value > 0.0 : value >= 0.0
     if !isfinite(value) || !lower_bound_is_valid || value > 1.0
@@ -63,7 +75,21 @@ function _validate_fraction(technology, value, field_name; strictly_positive=fal
     return true
 end
 
-function validate_technology(technology::StorageTechnology)
+function _validate_lifetime(
+    technology::Union{SupplyTechnology, StorageTechnology},
+)
+    if get_lifetime(technology) <= 0
+        @error(
+            "Technology lifetime must be positive",
+            technology=get_name(technology),
+            lifetime=get_lifetime(technology),
+        )
+        return false
+    end
+    return true
+end
+
+function _validate_storage_fields(technology::StorageTechnology)
     is_valid = true
 
     is_valid &= _validate_nonnegative_limits(
@@ -136,15 +162,42 @@ function validate_technology(technology::StorageTechnology)
         strictly_positive=true,
     )
 
-    if get_lifetime(technology) <= 0
-        @error(
-            "Storage lifetime must be positive",
-            technology=get_name(technology),
-            lifetime=get_lifetime(technology),
-        )
-        is_valid = false
-    end
+    return is_valid
+end
 
+validate_technology(technology::SupplyTechnology) =
+    _validate_lifetime(technology)
+
+function validate_technology(technology::StorageTechnology)
+    is_valid = _validate_lifetime(technology)
+    is_valid &= _validate_storage_fields(technology)
+    return is_valid
+end
+
+function _validate_transmission_fields(technology::TransmissionTechnology)
+    is_valid = _validate_nonnegative_limits(
+        technology,
+        get_capacity_limits(technology),
+        "Transport capacity limits",
+    )
+    is_valid &= _validate_positive_value(
+        technology,
+        get_unit_size(technology),
+        "Transport unit size",
+    )
+    return is_valid
+end
+
+validate_technology(technology::TransmissionTechnology) =
+    _validate_transmission_fields(technology)
+
+function validate_technology(technology::AggregateTransportTechnology)
+    is_valid = _validate_transmission_fields(technology)
+    is_valid &= _validate_fraction(
+        technology,
+        get_line_loss(technology),
+        "Aggregate transport line loss",
+    )
     return is_valid
 end
 
@@ -160,11 +213,34 @@ Return `true` if the technology is valid.
 """
 validate_technology_with_portfolio(::Technology, ::Portfolio) = true
 
-function _validate_unique_references(technology, references, reference_type)
+function _validate_unique_region_id(
+    region::RegionTopology,
+    portfolio::Portfolio,
+)
+    region_id = get_id(region)
+    for stored_region in get_regions(RegionTopology, portfolio)
+        if get_id(stored_region) == region_id
+            @error(
+                "Region ID is already attached to the portfolio",
+                region=summary(region),
+                id=region_id,
+                stored_region=summary(stored_region),
+            )
+            return false
+        end
+    end
+    return true
+end
+
+function _validate_unique_references(
+    technology::Technology,
+    references,
+    reference_type::AbstractString,
+)
     uuids = IS.get_uuid.(references)
     if !allunique(uuids)
         @error(
-            "Storage technology contains duplicate $reference_type references",
+            "Technology contains duplicate $reference_type references",
             technology=get_name(technology),
         )
         return false
@@ -173,16 +249,16 @@ function _validate_unique_references(technology, references, reference_type)
 end
 
 function _validate_attached_references(
-    technology,
+    technology::Technology,
     references,
-    portfolio,
-    reference_type,
+    portfolio::Portfolio,
+    reference_type::AbstractString,
 )
     is_valid = true
     for reference in references
         if !IS.has_component(portfolio.data, reference)
             @error(
-                "Storage technology references a $reference_type that is not attached to the portfolio",
+                "Technology references a $reference_type that is not attached to the portfolio",
                 technology=get_name(technology),
                 reference=summary(reference),
             )
@@ -192,34 +268,71 @@ function _validate_attached_references(
     return is_valid
 end
 
-function validate_technology_with_portfolio(
-    technology::StorageTechnology,
+function _validate_region_references(
+    technology::Union{ResourceTechnology, DemandTechnology},
     portfolio::Portfolio,
 )
-    is_valid = true
     regions = get_region(technology)
     if isempty(regions)
         @error(
-            "Storage technology must reference at least one region",
+            "Technology must reference at least one region",
             technology=get_name(technology),
         )
-        is_valid = false
-    else
-        is_valid &= _validate_unique_references(technology, regions, "region")
-        is_valid &=
-            _validate_attached_references(technology, regions, portfolio, "region")
+        return false
     end
 
-    requirements = get_requirements(technology)
-    is_valid &= _validate_unique_references(technology, requirements, "requirement")
-    is_valid &= _validate_attached_references(
-        technology,
-        requirements,
-        portfolio,
-        "requirement",
-    )
-
+    is_valid = _validate_unique_references(technology, regions, "region")
+    is_valid &=
+        _validate_attached_references(technology, regions, portfolio, "region")
     return is_valid
+end
+
+_get_transport_endpoints(technology::AggregateTransportTechnology) = (
+    get_start_region(technology),
+    get_end_region(technology),
+)
+
+_get_transport_endpoints(technology::NodalACTransportTechnology) = (
+    get_start_node(technology),
+    get_end_node(technology),
+)
+
+_get_transport_endpoints(technology::NodalHVDCTransportTechnology) = (
+    get_start_node(technology),
+    get_end_node(technology),
+)
+
+function _validate_transport_endpoints(
+    technology::TransmissionTechnology,
+    portfolio::Portfolio,
+)
+    start_endpoint, end_endpoint = _get_transport_endpoints(technology)
+    is_valid = true
+    for (endpoint_name, endpoint) in
+        (("start", start_endpoint), ("end", end_endpoint))
+        if !IS.has_component(portfolio.data, endpoint)
+            @error(
+                "Transport endpoint is not attached to the portfolio",
+                technology=get_name(technology),
+                endpoint=endpoint_name,
+                reference=summary(endpoint),
+            )
+            is_valid = false
+        end
+    end
+    return is_valid
+end
+
+validate_technology_with_portfolio(
+    technology::TransmissionTechnology,
+    portfolio::Portfolio,
+) = _validate_transport_endpoints(technology, portfolio)
+
+function validate_technology_with_portfolio(
+    technology::Union{ResourceTechnology, DemandTechnology},
+    portfolio::Portfolio,
+)
+    return _validate_region_references(technology, portfolio)
 end
 
 function _validate_or_skip!(
@@ -230,6 +343,17 @@ function _validate_or_skip!(
     if !skip_validation &&
        !validate_technology_with_portfolio(technology, portfolio)
         throw(IS.InvalidValue("Invalid value for $(summary(technology))"))
+    end
+    return skip_validation
+end
+
+function _validate_or_skip!(
+    portfolio::Portfolio,
+    region::RegionTopology,
+    skip_validation::Bool,
+)
+    if !skip_validation && !_validate_unique_region_id(region, portfolio)
+        throw(IS.InvalidValue("Invalid value for $(summary(region))"))
     end
     return skip_validation
 end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -1,4 +1,8 @@
-function make_storage_for_validation(name, duration_limits)
+@testset "Storage technology insertion validation" begin
+    portfolio = Portfolio()
+    attached_region = Zone(; name="attached_region", id=1)
+    add_region!(portfolio, attached_region)
+
     financial_data = TechnologyFinancialData(;
         capital_recovery_period=20,
         technology_base_year=2030,
@@ -7,58 +11,63 @@ function make_storage_for_validation(name, duration_limits)
         return_on_equity=0.12,
         tax_rate=0.21,
     )
-    return StorageTechnology{PSY.EnergyReservoirStorage}(;
-        name,
-        id=1,
+    storage_defaults = (;
         available=true,
-        region=RegionTopology[],
         power_systems_type="EnergyReservoirStorage",
         storage_tech=StorageTech.LIB,
-        duration_limits,
         financial_data,
     )
-end
 
-@testset "Technology validation" begin
-    portfolio = Portfolio()
-    ranged_duration = make_storage_for_validation(
-        "ranged_duration",
-        (min=2.0, max=4.0),
+    valid_storage = StorageTechnology{PSY.EnergyReservoirStorage}(;
+        storage_defaults...,
+        name="valid_storage",
+        id=1,
+        region=RegionTopology[attached_region],
     )
-    fixed_duration = make_storage_for_validation(
-        "fixed_duration",
-        (min=4.0, max=4.0),
-    )
-    reversed_duration = make_storage_for_validation(
-        "reversed_duration",
-        (min=4.0, max=2.0),
-    )
+    add_technology!(portfolio, valid_storage)
+    @test get_technology(typeof(valid_storage), portfolio, "valid_storage") ===
+          valid_storage
 
-    @test validate_technology(ranged_duration)
-    @test validate_technology(fixed_duration)
-    @test validate_technology_with_portfolio(ranged_duration, portfolio)
-    @test IS.validate_struct(ranged_duration)
-
-    @test_logs(
-        (:error, r"Storage duration limits must be in ascending order"),
-        @test !validate_technology(reversed_duration)
+    invalid_duration = StorageTechnology{PSY.EnergyReservoirStorage}(;
+        storage_defaults...,
+        name="invalid_duration",
+        id=2,
+        region=RegionTopology[attached_region],
+        duration_limits=(min=4.0, max=2.0),
     )
     @test_logs(
         (:error, r"Storage duration limits must be in ascending order"),
-        @test !IS.validate_struct(reversed_duration)
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(portfolio, invalid_duration)),
+    )
+    @test isnothing(
+        get_technology(typeof(invalid_duration), portfolio, "invalid_duration"),
     )
 
-    @test isnothing(check_technology(portfolio, ranged_duration))
-    @test isnothing(check_technologies(portfolio, [ranged_duration, fixed_duration]))
-    @test_logs(
-        (:error, r"Storage duration limits must be in ascending order"),
-        @test_throws IS.InvalidValue check_technology(portfolio, reversed_duration)
+    detached_region = Zone(; name="detached_region", id=2)
+    invalid_region = StorageTechnology{PSY.EnergyReservoirStorage}(;
+        storage_defaults...,
+        name="invalid_region",
+        id=3,
+        region=RegionTopology[detached_region],
     )
     @test_logs(
-        (:error, r"Storage duration limits must be in ascending order"),
-        @test_throws IS.InvalidValue check_technologies(
-            portfolio,
-            [ranged_duration, reversed_duration],
-        )
+        (:error, r"region that is not attached to the portfolio"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(portfolio, invalid_region)),
     )
+    @test isnothing(
+        get_technology(typeof(invalid_region), portfolio, "invalid_region"),
+    )
+
+    skipped_invalid = StorageTechnology{PSY.EnergyReservoirStorage}(;
+        storage_defaults...,
+        name="skipped_invalid",
+        id=4,
+        region=RegionTopology[attached_region],
+        duration_limits=(min=4.0, max=2.0),
+    )
+    add_technology!(portfolio, skipped_invalid; skip_validation=true)
+    @test get_technology(typeof(skipped_invalid), portfolio, "skipped_invalid") ===
+          skipped_invalid
 end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -1,0 +1,63 @@
+function make_storage_for_validation(name, duration_limits)
+    financial_data = TechnologyFinancialData(;
+        capital_recovery_period=20,
+        technology_base_year=2030,
+        debt_fraction=0.4,
+        debt_rate=0.05,
+        return_on_equity=0.12,
+        tax_rate=0.21,
+    )
+    return StorageTechnology{PSY.EnergyReservoirStorage}(;
+        name,
+        id=1,
+        available=true,
+        region=RegionTopology[],
+        power_systems_type="EnergyReservoirStorage",
+        storage_tech=StorageTech.LIB,
+        duration_limits,
+        financial_data,
+    )
+end
+
+@testset "Technology validation" begin
+    portfolio = Portfolio()
+    ranged_duration = make_storage_for_validation(
+        "ranged_duration",
+        (min=2.0, max=4.0),
+    )
+    fixed_duration = make_storage_for_validation(
+        "fixed_duration",
+        (min=4.0, max=4.0),
+    )
+    reversed_duration = make_storage_for_validation(
+        "reversed_duration",
+        (min=4.0, max=2.0),
+    )
+
+    @test validate_technology(ranged_duration)
+    @test validate_technology(fixed_duration)
+    @test IS.validate_struct(ranged_duration)
+
+    @test_logs(
+        (:error, r"Storage duration limits must be in ascending order"),
+        @test !validate_technology(reversed_duration)
+    )
+    @test_logs(
+        (:error, r"Storage duration limits must be in ascending order"),
+        @test !IS.validate_struct(reversed_duration)
+    )
+
+    @test isnothing(check_technology(portfolio, ranged_duration))
+    @test isnothing(check_technologies(portfolio, [ranged_duration, fixed_duration]))
+    @test_logs(
+        (:error, r"Storage duration limits must be in ascending order"),
+        @test_throws IS.InvalidValue check_technology(portfolio, reversed_duration)
+    )
+    @test_logs(
+        (:error, r"Storage duration limits must be in ascending order"),
+        @test_throws IS.InvalidValue check_technologies(
+            portfolio,
+            [ranged_duration, reversed_duration],
+        )
+    )
+end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -1,7 +1,7 @@
-@testset "Storage technology insertion validation" begin
-    portfolio = Portfolio()
+@testset "Storage validation" begin
+    port = Portfolio()
     attached_region = Zone(; name="attached_region", id=1)
-    add_region!(portfolio, attached_region)
+    add_region!(port, attached_region)
 
     financial_data = TechnologyFinancialData(;
         capital_recovery_period=20,
@@ -24,8 +24,8 @@
         id=1,
         region=RegionTopology[attached_region],
     )
-    add_technology!(portfolio, valid_storage)
-    @test get_technology(typeof(valid_storage), portfolio, "valid_storage") ===
+    add_technology!(port, valid_storage)
+    @test get_technology(typeof(valid_storage), port, "valid_storage") ===
           valid_storage
 
     invalid_duration = StorageTechnology{PSY.EnergyReservoirStorage}(;
@@ -38,10 +38,10 @@
     @test_logs(
         (:error, r"Storage duration limits must be in ascending order"),
         min_level=Logging.Error,
-        @test_throws(IS.InvalidValue, add_technology!(portfolio, invalid_duration)),
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_duration)),
     )
     @test isnothing(
-        get_technology(typeof(invalid_duration), portfolio, "invalid_duration"),
+        get_technology(typeof(invalid_duration), port, "invalid_duration"),
     )
 
     detached_region = Zone(; name="detached_region", id=2)
@@ -54,10 +54,10 @@
     @test_logs(
         (:error, r"region that is not attached to the portfolio"),
         min_level=Logging.Error,
-        @test_throws(IS.InvalidValue, add_technology!(portfolio, invalid_region)),
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_region)),
     )
     @test isnothing(
-        get_technology(typeof(invalid_region), portfolio, "invalid_region"),
+        get_technology(typeof(invalid_region), port, "invalid_region"),
     )
 
     skipped_invalid = StorageTechnology{PSY.EnergyReservoirStorage}(;
@@ -67,7 +67,149 @@
         region=RegionTopology[attached_region],
         duration_limits=(min=4.0, max=2.0),
     )
-    add_technology!(portfolio, skipped_invalid; skip_validation=true)
-    @test get_technology(typeof(skipped_invalid), portfolio, "skipped_invalid") ===
+    add_technology!(port, skipped_invalid; skip_validation=true)
+    @test get_technology(typeof(skipped_invalid), port, "skipped_invalid") ===
           skipped_invalid
+end
+
+@testset "Demand region validation" begin
+    port = Portfolio()
+    attached_region = Zone(; name="demand_region", id=10)
+    add_region!(port, attached_region)
+
+    valid_demand = DemandRequirement{PSY.PowerLoad}(;
+        available=true,
+        name="valid_demand",
+        id=10,
+        power_systems_type="PowerLoad",
+        value_of_lost_load=1000.0,
+        region=RegionTopology[attached_region],
+    )
+    add_technology!(port, valid_demand)
+    @test get_technology(typeof(valid_demand), port, "valid_demand") === valid_demand
+
+    invalid_demand = DemandRequirement{PSY.PowerLoad}(;
+        available=true,
+        name="invalid_demand",
+        id=11,
+        power_systems_type="PowerLoad",
+        value_of_lost_load=1000.0,
+        region=RegionTopology[],
+    )
+    @test_logs(
+        (:error, r"Technology must reference at least one region"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_demand)),
+    )
+    @test isnothing(get_technology(typeof(invalid_demand), port, "invalid_demand"))
+end
+
+@testset "Region ID uniqueness" begin
+    port = Portfolio()
+    attached_region = Zone(; name="attached_region", id=101)
+    add_region!(port, attached_region)
+
+    duplicate_region_id = Node(; name="duplicate_region_id", id=101)
+    @test_logs(
+        (:error, r"Region ID is already attached to the portfolio"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_region!(port, duplicate_region_id)),
+    )
+    @test isnothing(get_region(Node, port, "duplicate_region_id"))
+end
+
+@testset "Transport validation" begin
+    port = Portfolio()
+    start_zone = Zone(; name="start_zone", id=101)
+    end_zone = Zone(; name="end_zone", id=102)
+    start_node = Node(; name="start_node", id=201)
+    end_node = Node(; name="end_node", id=202)
+    foreach(
+        region -> add_region!(port, region),
+        (start_zone, end_zone, start_node, end_node),
+    )
+
+    financial_data = TechnologyFinancialData(;
+        capital_recovery_period=20,
+        technology_base_year=2030,
+        debt_fraction=0.4,
+        debt_rate=0.05,
+        return_on_equity=0.12,
+        tax_rate=0.21,
+    )
+    transport_defaults = (;
+        available=true,
+        power_systems_type="ACBranch",
+        financial_data,
+    )
+
+    valid_transport = AggregateTransportTechnology{PSY.ACBranch}(;
+        transport_defaults...,
+        name="valid_transport",
+        id=301,
+        start_region=start_zone,
+        end_region=end_zone,
+        capacity_limits=(min=0.0, max=100.0),
+        unit_size=1.0,
+        line_loss=0.05,
+    )
+    add_technology!(port, valid_transport)
+    @test get_technology(typeof(valid_transport), port, "valid_transport") ===
+          valid_transport
+
+    invalid_capacity = AggregateTransportTechnology{PSY.ACBranch}(;
+        transport_defaults...,
+        name="invalid_capacity",
+        id=302,
+        start_region=start_zone,
+        end_region=end_zone,
+        capacity_limits=(min=100.0, max=50.0),
+    )
+    @test_logs(
+        (:error, r"Transport capacity limits must be in ascending order"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_capacity)),
+    )
+
+    invalid_unit_size = NodalACTransportTechnology{PSY.ACBranch}(;
+        transport_defaults...,
+        name="invalid_unit_size",
+        id=303,
+        start_node,
+        end_node,
+        unit_size=0.0,
+    )
+    @test_logs(
+        (:error, r"Transport unit size must be finite and positive"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_unit_size)),
+    )
+
+    invalid_line_loss = AggregateTransportTechnology{PSY.ACBranch}(;
+        transport_defaults...,
+        name="invalid_line_loss",
+        id=304,
+        start_region=start_zone,
+        end_region=end_zone,
+        line_loss=1.1,
+    )
+    @test_logs(
+        (:error, r"Aggregate transport line loss must be in \[0, 1\]"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_line_loss)),
+    )
+
+    detached_node = Node(; name="detached_node", id=203)
+    invalid_endpoint = NodalHVDCTransportTechnology{PSY.ACBranch}(;
+        transport_defaults...,
+        name="invalid_endpoint",
+        id=305,
+        start_node,
+        end_node=detached_node,
+    )
+    @test_logs(
+        (:error, r"Transport endpoint is not attached to the portfolio"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, invalid_endpoint)),
+    )
 end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -25,8 +25,7 @@
         region=RegionTopology[attached_region],
     )
     add_technology!(port, valid_storage)
-    @test get_technology(typeof(valid_storage), port, "valid_storage") ===
-          valid_storage
+    @test get_technology(typeof(valid_storage), port, "valid_storage") === valid_storage
 
     invalid_duration = StorageTechnology{PSY.EnergyReservoirStorage}(;
         storage_defaults...,
@@ -37,12 +36,10 @@
     )
     @test_logs(
         (:error, r"Storage duration limits must be in ascending order"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_duration)),
     )
-    @test isnothing(
-        get_technology(typeof(invalid_duration), port, "invalid_duration"),
-    )
+    @test isnothing(get_technology(typeof(invalid_duration), port, "invalid_duration"))
 
     detached_region = Zone(; name="detached_region", id=2)
     invalid_region = StorageTechnology{PSY.EnergyReservoirStorage}(;
@@ -53,12 +50,10 @@
     )
     @test_logs(
         (:error, r"region that is not attached to the portfolio"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_region)),
     )
-    @test isnothing(
-        get_technology(typeof(invalid_region), port, "invalid_region"),
-    )
+    @test isnothing(get_technology(typeof(invalid_region), port, "invalid_region"))
 
     skipped_invalid = StorageTechnology{PSY.EnergyReservoirStorage}(;
         storage_defaults...,
@@ -79,12 +74,12 @@ end
 
     @test_logs(
         (:error, r"Technology lifetime must be positive"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, check_technology(port, supply)),
     )
     @test_logs(
         (:error, r"Technology lifetime must be positive"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, check_technologies(port, [supply])),
     )
 end
@@ -117,18 +112,11 @@ end
     )
     @test_logs(
         (:error, r"Technology contains duplicate region references"),
-        min_level=Logging.Error,
-        @test_throws(
-            IS.InvalidValue,
-            add_technology!(port, duplicate_region_demand),
-        ),
+        min_level = Logging.Error,
+        @test_throws(IS.InvalidValue, add_technology!(port, duplicate_region_demand),),
     )
     @test isnothing(
-        get_technology(
-            typeof(duplicate_region_demand),
-            port,
-            "duplicate_region_demand",
-        ),
+        get_technology(typeof(duplicate_region_demand), port, "duplicate_region_demand"),
     )
 
     invalid_demand = DemandRequirement{PSY.PowerLoad}(;
@@ -141,7 +129,7 @@ end
     )
     @test_logs(
         (:error, r"Technology must reference at least one region"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_demand)),
     )
     @test isnothing(get_technology(typeof(invalid_demand), port, "invalid_demand"))
@@ -155,7 +143,7 @@ end
     duplicate_region_id = Node(; name="duplicate_region_id", id=101)
     @test_logs(
         (:error, r"Region ID is already attached to the portfolio"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_region!(port, duplicate_region_id)),
     )
     @test isnothing(get_region(Node, port, "duplicate_region_id"))
@@ -180,11 +168,7 @@ end
         return_on_equity=0.12,
         tax_rate=0.21,
     )
-    transport_defaults = (;
-        available=true,
-        power_systems_type="ACBranch",
-        financial_data,
-    )
+    transport_defaults = (; available=true, power_systems_type="ACBranch", financial_data)
 
     valid_transport = AggregateTransportTechnology{PSY.ACBranch}(;
         transport_defaults...,
@@ -210,7 +194,7 @@ end
     )
     @test_logs(
         (:error, r"Transport capacity limits must be in ascending order"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_capacity)),
     )
 
@@ -224,7 +208,7 @@ end
     )
     @test_logs(
         (:error, r"Transport unit size must be finite and positive"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_unit_size)),
     )
 
@@ -238,7 +222,7 @@ end
     )
     @test_logs(
         (:error, r"Aggregate transport line loss must be in \[0, 1\]"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_line_loss)),
     )
 
@@ -252,7 +236,7 @@ end
     )
     @test_logs(
         (:error, r"Transport endpoint is not attached to the portfolio"),
-        min_level=Logging.Error,
+        min_level = Logging.Error,
         @test_throws(IS.InvalidValue, add_technology!(port, invalid_endpoint)),
     )
 end

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -73,12 +73,12 @@ end
     PSIP.set_lifetime!(supply, 0)
 
     @test_logs(
-        (:error, r"Technology lifetime must be positive"),
+        (:error, r"Technology lifetime must be finite and positive"),
         min_level = Logging.Error,
         @test_throws(IS.InvalidValue, check_technology(port, supply)),
     )
     @test_logs(
-        (:error, r"Technology lifetime must be positive"),
+        (:error, r"Technology lifetime must be finite and positive"),
         min_level = Logging.Error,
         @test_throws(IS.InvalidValue, check_technologies(port, [supply])),
     )

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -70,7 +70,7 @@ end
 @testset "Technology checking" begin
     port = build_portfolio()
     supply = first(get_technologies(SupplyTechnology, port))
-    PSIP.set_lifetime!(supply, 0)
+    set_lifetime!(supply, 0)
 
     @test_logs(
         (:error, r"Technology lifetime must be finite and positive"),
@@ -81,6 +81,83 @@ end
         (:error, r"Technology lifetime must be finite and positive"),
         min_level = Logging.Error,
         @test_throws(IS.InvalidValue, check_technologies(port, [supply])),
+    )
+end
+
+@testset "Supply validation" begin
+    supply = first(get_technologies(SupplyTechnology, build_portfolio()))
+
+    capacity_limits = get_capacity_limits(supply)
+    set_capacity_limits!(supply, (min=-1.0, max=capacity_limits.max))
+    @test_logs(
+        (:error, r"Supply capacity limits must be nonnegative"),
+        min_level = Logging.Error,
+        @test(!validate_technology(supply)),
+    )
+    set_capacity_limits!(supply, capacity_limits)
+
+    unit_size = get_unit_size(supply)
+    set_unit_size!(supply, -1.0)
+    @test_logs(
+        (:error, r"Supply unit size must be finite and nonnegative"),
+        min_level = Logging.Error,
+        @test(!validate_technology(supply)),
+    )
+    set_unit_size!(supply, unit_size)
+
+    min_generation_fraction = get_min_generation_fraction(supply)
+    set_min_generation_fraction!(supply, 1.1)
+    @test_logs(
+        (:error, r"Supply minimum generation fraction must be in \[0, 1\]"),
+        min_level = Logging.Error,
+        @test(!validate_technology(supply)),
+    )
+    set_min_generation_fraction!(supply, min_generation_fraction)
+end
+
+@testset "Colocated supply-storage validation" begin
+    port = Portfolio()
+    attached_region = Zone(; name="colocated_region", id=20)
+    add_region!(port, attached_region)
+
+    financial_data = TechnologyFinancialData(;
+        capital_recovery_period=20,
+        technology_base_year=2030,
+        debt_fraction=0.4,
+        debt_rate=0.05,
+        return_on_equity=0.12,
+        tax_rate=0.21,
+    )
+    colocated = ColocatedSupplyStorageTechnology{PSY.RenewableDispatch}(;
+        name="valid_colocated",
+        id=20,
+        operation_costs_inverter=StorageCost(),
+        financial_data,
+        inverter_efficiency=0.96,
+        power_systems_type="RenewableDispatch",
+        inverter_supply_ratio=1.0,
+        capital_costs_inverter=LinearCurve(0.0),
+        available=true,
+        region=RegionTopology[attached_region],
+    )
+    add_technology!(port, colocated)
+    @test get_technology(typeof(colocated), port, "valid_colocated") === colocated
+
+    duration_limits = get_duration_limits(colocated)
+    set_duration_limits!(colocated, (min=4.0, max=2.0))
+    @test_logs(
+        (:error, r"Colocated storage duration limits must be in ascending order"),
+        min_level = Logging.Error,
+        @test(!validate_technology(colocated)),
+    )
+    set_duration_limits!(colocated, duration_limits)
+
+    set_min_inverter_capacity!(colocated, 2.0)
+    set_max_inverter_capacity!(colocated, 1.0)
+    @test_logs(
+        (:error, r"Colocated inverter capacity limits must be in ascending order"),
+        min_level = Logging.Error,
+        @test(!validate_technology(colocated)),
     )
 end
 

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -72,10 +72,29 @@
           skipped_invalid
 end
 
+@testset "Technology checking" begin
+    port = build_portfolio()
+    supply = first(get_technologies(SupplyTechnology, port))
+    PSIP.set_lifetime!(supply, 0)
+
+    @test_logs(
+        (:error, r"Technology lifetime must be positive"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, check_technology(port, supply)),
+    )
+    @test_logs(
+        (:error, r"Technology lifetime must be positive"),
+        min_level=Logging.Error,
+        @test_throws(IS.InvalidValue, check_technologies(port, [supply])),
+    )
+end
+
 @testset "Demand region validation" begin
     port = Portfolio()
     attached_region = Zone(; name="demand_region", id=10)
+    second_region = Zone(; name="second_demand_region", id=11)
     add_region!(port, attached_region)
+    add_region!(port, second_region)
 
     valid_demand = DemandRequirement{PSY.PowerLoad}(;
         available=true,
@@ -83,15 +102,39 @@ end
         id=10,
         power_systems_type="PowerLoad",
         value_of_lost_load=1000.0,
-        region=RegionTopology[attached_region],
+        region=RegionTopology[attached_region, second_region],
     )
     add_technology!(port, valid_demand)
     @test get_technology(typeof(valid_demand), port, "valid_demand") === valid_demand
 
+    duplicate_region_demand = DemandRequirement{PSY.PowerLoad}(;
+        available=true,
+        name="duplicate_region_demand",
+        id=11,
+        power_systems_type="PowerLoad",
+        value_of_lost_load=1000.0,
+        region=RegionTopology[attached_region, attached_region],
+    )
+    @test_logs(
+        (:error, r"Technology contains duplicate region references"),
+        min_level=Logging.Error,
+        @test_throws(
+            IS.InvalidValue,
+            add_technology!(port, duplicate_region_demand),
+        ),
+    )
+    @test isnothing(
+        get_technology(
+            typeof(duplicate_region_demand),
+            port,
+            "duplicate_region_demand",
+        ),
+    )
+
     invalid_demand = DemandRequirement{PSY.PowerLoad}(;
         available=true,
         name="invalid_demand",
-        id=11,
+        id=12,
         power_systems_type="PowerLoad",
         value_of_lost_load=1000.0,
         region=RegionTopology[],

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -36,6 +36,7 @@ end
 
     @test validate_technology(ranged_duration)
     @test validate_technology(fixed_duration)
+    @test validate_technology_with_portfolio(ranged_duration, portfolio)
     @test IS.validate_struct(ranged_duration)
 
     @test_logs(


### PR DESCRIPTION
This PR adds validation for investment portfolio inputs before they are used to construct PSIN models. This prevents invalid values from surfacing later as model infeasibilities.

Validation can still be bypassed explicitly with `skip_validation=true`. 

The validations implemented in this PR are summarized in the table below. The initial scope focuses on technology types and fields currently represented in PSIN.

`✓` validated, `×` not validated and `-` not applicable.

| | `SupplyTechnology` | `StorageTechnology` | `ColocatedSupplyStorageTechnology` | `DemandTechnology` | `TransmissionTechnology` | `RegionTopology` |
|---|:---:|:---:|:---:|:---:|:---:|:---:|
| Positive lifetime | ✓ | ✓ | ✓ | - | - | - |
| Finite, nonnegative and ordered capacity limits | ✓ | ✓ | ✓ | - | ✓ | - |
| Finite, nonnegative and ordered duration limits | - | ✓ | ✓ | - | - | - |
| Nonnegative unit size | ✓ | ✓ | - | - | - | - |
| Positive unit size | - | - | - | - | ✓ | - |
| Storage charging and discharging efficiency in `(0, 1]` | - | ✓ | ✓ | - | - | - |
| Inverter efficiency in `(0, 1]` | - | - | ✓ | - | - | - |
| Storage losses in `[0, 1]` | - | ✓ | ✓ | - | - | - |
| Supply minimum generation fraction in `[0, 1]` | ✓ | - | - | - | - | - |
| Storage minimum discharge fraction in `[0, 1]` | - | ✓ | - | - | - | - |
| Finite, nonnegative and ordered inverter capacity bounds | - | - | ✓ | - | - | - |
| Region references are nonempty, unique and attached | ✓ | ✓ | ✓ | ✓ | - | - |
| Aggregate transport line loss in `[0, 1]` | - | - | - | - | ✓ | - |
| Transport endpoints are attached | - | - | - | - | ✓ | - |
| Region IDs are unique across region types | - | - | - | - | - | ✓ |