### PR TITLE
Order-independent requirement deserialization

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -503,9 +503,10 @@ end
 
 function deserialize_components!(portfolio::Portfolio, raw)
     # Convert the array of components into type-specific arrays to allow addition by type.
-    # Need to maintain an order here and deserialize regions first so they can
-    # be referenced when deserializing technologies
+    # Maintain dependency order so referenced components exist before technologies
+    # are constructed. Technologies may reference both regions and requirements.
     technologies = OrderedDict{Type, Vector{Dict}}()
+    requirements = OrderedDict{Type, Vector{Dict}}()
     regions = OrderedDict{Type, Vector{Dict}}()
     for component in raw["components"]
         type = IS.get_type_from_serialization_data(component)
@@ -514,6 +515,12 @@ function deserialize_components!(portfolio::Portfolio, raw)
             if components === nothing
                 components = Vector{Dict}()
                 regions[type] = components
+            end
+        elseif type <: Requirement
+            components = get(requirements, type, nothing)
+            if components === nothing
+                components = Vector{Dict}()
+                requirements[type] = components
             end
         else
             components = get(technologies, type, nothing)
@@ -524,7 +531,7 @@ function deserialize_components!(portfolio::Portfolio, raw)
         end
         push!(components, component)
     end
-    data = merge(regions, technologies)
+    data = merge(regions, requirements, technologies)
 
     # Add each type to this as we parse.
     parsed_types = Set()

--- a/src/utils/print_pt_v3.jl
+++ b/src/utils/print_pt_v3.jl
@@ -127,21 +127,21 @@ function Base.show(io::IO, ::MIME"text/plain", p::Portfolio)
 end
 
 function Base.show(io::IO, ::MIME"text/html", p::Portfolio)
-    show_portfolio_table(io, p; backend=:html, standalone=false)
+    show_portfolio_table(io, p; backend=:html, stand_alone=false)
     println(io)
     show_region_topology_table(
         io,
         p;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     show_technologies_table(
         io,
         p;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     println(io)
     println(io, "Time Series")
@@ -150,7 +150,7 @@ function Base.show(io::IO, ::MIME"text/html", p::Portfolio)
         p.data;
         backend=:html,
         table_format=tf_html_simple,
-        standalone=false,
+        stand_alone=false,
     )
     return
 end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -159,22 +159,13 @@ end
         data = open(path, "r") do io
             JSON3.read(io, Dict)
         end
-        component_type_order = [
-            "StorageTechnology",
-            "EnergyShareRequirements",
-            "Zone",
-        ]
-        type_rank = Dict(
-            type => rank for (rank, type) in enumerate(component_type_order)
-        )
+        component_type_order = ["StorageTechnology", "EnergyShareRequirements", "Zone"]
+        type_rank = Dict(type => rank for (rank, type) in enumerate(component_type_order))
         components = data["data"]["components"]
         sort!(
             components;
-            by=x -> get(
-                type_rank,
-                x["__metadata__"]["type"],
-                length(component_type_order) + 1,
-            ),
+            by=x ->
+                get(type_rank, x["__metadata__"]["type"], length(component_type_order) + 1),
         )
         open(path, "w") do io
             JSON3.pretty(io, data)

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -12,6 +12,22 @@
     end
 end
 
+@testset "Test serialization of technology requirement references" begin
+    portfolio = build_portfolio()
+    requirement = PSIP.get_requirement(EnergyShareRequirements, portfolio, "test_esr")
+    storage = first(get_technologies(StorageTechnology, portfolio))
+    set_requirements!(storage, [requirement])
+
+    portfolio2 = validate_serialization(portfolio; time_series_read_only=true)
+    storage2 = get_technology(typeof(storage), portfolio2, PSIP.get_name(storage))
+    @test storage2 !== nothing
+    result = IS.compare_values(storage, storage2; compare_uuids=false)
+    @test result
+
+    requirement2 = PSIP.get_requirement(EnergyShareRequirements, portfolio2, "test_esr")
+    @test has_requirement(storage2, requirement2)
+end
+
 @testset "Test serialization of regions" begin
     portfolio = build_portfolio()
     portfolio2 = validate_serialization(portfolio; time_series_read_only=true)
@@ -128,5 +144,49 @@ end
                 @test schedule.results[key][key2] == schedule2.results[key][key2]
             end
         end
+    end
+end
+
+@testset "Test deserialization of component dependency order" begin
+    portfolio = build_portfolio()
+    requirement = PSIP.get_requirement(EnergyShareRequirements, portfolio, "test_esr")
+    storage = first(get_technologies(StorageTechnology, portfolio))
+    set_requirements!(storage, [requirement])
+
+    mktempdir() do test_dir
+        path = joinpath(test_dir, "test_requirement_serialization.json")
+        PSIP.to_json(portfolio, path; force=true)
+        data = open(path, "r") do io
+            JSON3.read(io, Dict)
+        end
+        component_type_order = [
+            "StorageTechnology",
+            "EnergyShareRequirements",
+            "Zone",
+        ]
+        type_rank = Dict(
+            type => rank for (rank, type) in enumerate(component_type_order)
+        )
+        components = data["data"]["components"]
+        sort!(
+            components;
+            by=x -> get(
+                type_rank,
+                x["__metadata__"]["type"],
+                length(component_type_order) + 1,
+            ),
+        )
+        open(path, "w") do io
+            JSON3.pretty(io, data)
+        end
+
+        portfolio2 = Portfolio(path)
+        storage2 = get_technology(typeof(storage), portfolio2, PSIP.get_name(storage))
+        @test storage2 !== nothing
+        result = IS.compare_values(storage, storage2; compare_uuids=false)
+        @test result
+
+        requirement2 = PSIP.get_requirement(EnergyShareRequirements, portfolio2, "test_esr")
+        @test has_requirement(storage2, requirement2)
     end
 end


### PR DESCRIPTION
This PR makes requirement-reference deserialization independent of serialized component order. PSIP serializes technology requirements by `ID`, so requirements must be reconstructed and registered before technologies can resolve those references. 

The change preserves the existing reference-by-ID format and extends the dependency-ordering approach already used for regions. 

Without this ordering, technology requirement references are silently omitted during deserialization.